### PR TITLE
make datetimes timezone-aware

### DIFF
--- a/bolides/astro_utils.py
+++ b/bolides/astro_utils.py
@@ -7,6 +7,9 @@ import astropy.units as u
 from astropy.coordinates import ICRS, SkyCoord
 from astropy.time import Time
 
+from pytz import timezone
+utc = timezone('UTC')
+
 
 def get_phase(datetime):
     """Get lunar phase (0.01=new moon just happened, 0.99=new moon about to happen)"""
@@ -111,7 +114,10 @@ def sol_lon_to_datetime(lon, year):
 
     JD = sol_lon_to_jd(lon, year)
     t = Time(JD, format='jd', scale='utc')
-    return t.datetime
+    dt = t.datetime
+    utc = timezone('UTC')
+    dt = utc.localize(dt)
+    return dt
 
 
 def sol_lon_to_jd(lon, year):

--- a/bolides/astro_utils.py
+++ b/bolides/astro_utils.py
@@ -115,8 +115,11 @@ def sol_lon_to_datetime(lon, year):
     JD = sol_lon_to_jd(lon, year)
     t = Time(JD, format='jd', scale='utc')
     dt = t.datetime
+
+    # make the UTC datetime timezone-aware
     utc = timezone('UTC')
     dt = utc.localize(dt)
+
     return dt
 
 

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta
+from pytz import timezone
 import requests
 from warnings import warn, filterwarnings
 from tqdm import tqdm
@@ -23,6 +24,7 @@ _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
                'energy', 'energy_g16', 'energy_g17', 'brightness_g16', 'brightness_g17',
                'brightness_cat_g16', 'brightness_cat_g17', 'impact-e', 'alt', 'vel']
 
+utc = timezone('UTC')
 
 class BolideDataFrame(GeoDataFrame):
     """
@@ -223,13 +225,19 @@ class BolideDataFrame(GeoDataFrame):
 
         # drop data before start date, if specified
         if start is not None:
-            to_drop = self.datetime < datetime.fromisoformat(start)
-            new_bdf = self.drop(self.index[to_drop], inplace=inplace)
+            dt = datetime.fromisoformat(start)
+            if dt.tzname() == None:
+                dt = utc.localize(dt)
+            to_drop = self.datetime < dt
+            new_bdf = new_bdf.drop(new_bdf.index[to_drop], inplace=inplace)
         if inplace:
             new_bdf = self
         # drop data after end date, if specified
         if end is not None:
-            to_drop = new_bdf.datetime > datetime.fromisoformat(end)
+            dt = datetime.fromisoformat(end)
+            if dt.tzname() == None:
+                dt = utc.localize(dt)
+            to_drop = new_bdf.datetime > dt
             new_bdf = new_bdf.drop(new_bdf.index[to_drop], inplace=inplace)
         if inplace:
             new_bdf = self
@@ -258,6 +266,8 @@ class BolideDataFrame(GeoDataFrame):
         """
 
         dt = datetime.fromisoformat(datestr)
+        if dt.tzname() == None:
+            dt = utc.localize(dt)
         return self.iloc[(self['datetime'] - dt).abs().argsort()].head(n)
 
     def get_closest_by_loc(self, lon, lat, n=1):

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -213,6 +213,7 @@ class BolideDataFrame(GeoDataFrame):
         ----------
         start, end: str
             ISO-format strings that can be read by `~datetime.datetime.fromisoformat`.
+            If the timezone is not specified, it is assumed to be in UTC.
         inplace: bool
             If True, the `~BolideDataFrame` of this method is altered. If False, it is not, so the returned
             `~BolideDataFrame` must be used.
@@ -226,8 +227,12 @@ class BolideDataFrame(GeoDataFrame):
         # drop data before start date, if specified
         if start is not None:
             dt = datetime.fromisoformat(start)
+
+            # if timezone not given, make the datetime timezone-aware
+            # with UTC assumed as the timezone
             if dt.tzname() == None:
                 dt = utc.localize(dt)
+
             to_drop = self.datetime < dt
             new_bdf = new_bdf.drop(new_bdf.index[to_drop], inplace=inplace)
         if inplace:
@@ -235,8 +240,12 @@ class BolideDataFrame(GeoDataFrame):
         # drop data after end date, if specified
         if end is not None:
             dt = datetime.fromisoformat(end)
+
+            # if timezone not given, make the datetime timezone-aware
+            # with UTC assumed as the timezone
             if dt.tzname() == None:
                 dt = utc.localize(dt)
+
             to_drop = new_bdf.datetime > dt
             new_bdf = new_bdf.drop(new_bdf.index[to_drop], inplace=inplace)
         if inplace:
@@ -255,6 +264,7 @@ class BolideDataFrame(GeoDataFrame):
         ----------
         datestr : str
             ISO-format string that can be read by `~datetime.datetime.fromisoformat`.
+            If the timezone is not specified, it is assumed to be in UTC.
         n : int
             Number of closest detections to return.
 
@@ -266,8 +276,12 @@ class BolideDataFrame(GeoDataFrame):
         """
 
         dt = datetime.fromisoformat(datestr)
+
+        # if timezone not given, make the datetime timezone-aware
+        # with UTC assumed as the timezone
         if dt.tzname() == None:
             dt = utc.localize(dt)
+
         return self.iloc[(self['datetime'] - dt).abs().argsort()].head(n)
 
     def get_closest_by_loc(self, lon, lat, n=1):

--- a/bolides/sources.py
+++ b/bolides/sources.py
@@ -80,6 +80,7 @@ def usg():
     df['longitude'] = df['lon'].astype(float) * ((df['lon-dir'] == 'E') * 2 - 1)
     del df['lat'], df['lon'], df['lat-dir'], df['lon-dir']
     df['datetime'] = [datetime.fromisoformat(date) for date in df['date']]
+    # localize to UTC, as that is how USG datetimes are reported
     df['datetime'] = df['datetime'].dt.tz_localize('UTC')
     del df['date']
     numeric_cols = ['energy', 'impact-e', 'alt', 'vel', 'vx', 'vy', 'vz']
@@ -174,6 +175,8 @@ def gmn(date, loc_mode='begin'):
     df = pd.read_csv(buf, sep=';')
     df.columns = header
 
+    # convert the strings to datetimes in UTC. If the strings have timezone information,
+    # they will be converted to UTC, otherwise they are assumed to be in UTC.
     df['datetime'] = pd.to_datetime(df['datetime'], utc=True, format='ISO8601')
     if loc_mode == 'begin':
         df['latitude'] = df.LatBeg
@@ -203,10 +206,11 @@ def csv(file):
     df = pd.read_csv(file, index_col=0,
                      keep_default_na=False,
                      na_values='')
+
+    # convert the strings to datetimes in UTC. If the strings have timezone information,
+    # they will be converted to UTC, otherwise they are assumed to be in UTC.
     df['datetime'] = pd.to_datetime(df['datetime'], utc=True, format='ISO8601')
 
-    if df['datetime'].dt.tz is None:
-        df['datetime'] = df['datetime'].dt.tz_localize('UTC')
     gdf = add_geometry(df)
     return gdf
 


### PR DESCRIPTION
This PR closes #21 by making datetimes timezone-aware across the package. This is not the only way to fix the Pandas v2 compatibility problem, but making datetimes timezone-aware is good to do anyway to avoid any confusion.

When loading data from different sources, if the source data has timezones in its datetimes, they are converted to UTC. If the source data does not have timezones, datetimes are assumed to be in UTC, which is true for all current sources of data pulled from.