### PR TITLE
move energies to add_website_data

### DIFF
--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -18,10 +18,10 @@ from .utils import reconcile_input
 from .sources import glm_website, usg, pipeline, gmn, csv, remote
 
 _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
-               'confidenceRating', 'confidence', 'lightcurveStructure',
-               'energy', 'energy_g16', 'energy_g17', 'energy_g18',
-               'brightness_g16', 'brightness_g17', 'brightness_g18',
-               'brightness_cat_g16', 'brightness_cat_g17', 'brightness_cat_g18',
+               'confidenceRating', 'confidence', 'lightcurveStructure', 'energy',
+               'integrated_energy_g16', 'integrated_energy_g17', 'integrated_energy_g18',
+               'peak_energy_g16', 'peak_energy_g17', 'peak_energy_g18',
+               'peak_energy_cat_g16', 'peak_energy_cat_g17', 'peak_energy_cat_g18',
                'impact-e', 'alt', 'vel']
 
 utc = timezone('UTC')
@@ -945,25 +945,25 @@ class BolideDataFrame(GeoDataFrame):
 
         # if there is no _id column, we can't associate the website data to
         # the bolides in the BolideDataFrame
-        assert '_id' in self.columns
+        assert '_id' in self.columns, "BolideDataFrame must have an '_id' column"
 
         # check that ids is not a single string
-        assert type(ids) is not str
+        assert type(ids) is not str, "Input must be must be a list"
 
         # make ids a List if it is an iterable
         if hasattr(ids, '__iter__'):
             ids = list(ids)
 
             # check that all the given ids actually exist
-            assert all([_id in list(self._id) for _id in ids])
+            assert all([_id in list(self._id) for _id in ids]), "All given IDs must exist in the BolideDataFrame"
 
         # if no ids are given, we assume that we will obtain website data for each
         # event in the BolideDataFrame
         if ids == None:
             ids = list(self._id)
 
-        # at this point, unless the input was bad, ids should be a list
-        assert type(ids) is list
+        # at this point, unless the input was not iterable, ids should be a list
+        assert type(ids) is list, "Input must be a list"
 
         # get the data from the website by passing the ids
         from .sources import glm_website_event

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime, timedelta
 from pytz import timezone
-import requests
 from warnings import warn, filterwarnings
 from tqdm import tqdm
 
@@ -13,16 +12,17 @@ from geopandas import GeoDataFrame
 
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
-from lightkurve import LightCurve, LightCurveCollection
 
-from . import API_ENDPOINT_EVENT, MPLSTYLE, ROOT_PATH
+from . import MPLSTYLE, ROOT_PATH
 from .utils import reconcile_input
 from .sources import glm_website, usg, pipeline, gmn, csv, remote
 
 _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
                'confidenceRating', 'confidence', 'lightcurveStructure',
-               'energy', 'energy_g16', 'energy_g17', 'brightness_g16', 'brightness_g17',
-               'brightness_cat_g16', 'brightness_cat_g17', 'impact-e', 'alt', 'vel']
+               'energy', 'energy_g16', 'energy_g17', 'energy_g18',
+               'brightness_g16', 'brightness_g17', 'brightness_g18',
+               'brightness_cat_g16', 'brightness_cat_g17', 'brightness_cat_g18',
+               'impact-e', 'alt', 'vel']
 
 utc = timezone('UTC')
 
@@ -927,43 +927,66 @@ class BolideDataFrame(GeoDataFrame):
         return fig, ax
 
     def add_website_data(self, ids=None):
-        """Pull light curve data from neo-bolide.ndc.nasa.gov.
+        """Pull light curve and integrated energy data from neo-bolide.ndc.nasa.gov.
 
         Downloads light curve data from neo-bolide.ndc.nasa.gov, placing it
         into the BolideDataFrame as a column of `~lightkurve.LightCurveCollection` objects.
-        The column is named ``'lightcurves'``
+        The column is named ``'lightcurves'``. Integrated energy data is also downloaded
+        for different satellites and placed into columns starting with ``'energy_'``.
+        This method will only work with BolideDataFrames having an ``_id`` column containing
+        IDs from GLM bolide detections at neo-bolide.ndc.nasa.gov.
 
         Parameters
         ----------
         ids : list of str
-            Optional list of strings representing the bolide ID's that light curves are wanted for.
-            If not used, a light curve is added for every bolide in the BolideDataFrame.
+            Optional list of strings representing the bolide ID's that additional data is
+            needed for. If not used, data is added for every bolide in the BolideDataFrame.
         """
 
-        lclist = []
-        for num, row in tqdm(self.iterrows(), "Downloading data", total=len(self)):  # for each bolide
+        # if there is no _id column, we can't associate the website data to
+        # the bolides in the BolideDataFrame
+        assert '_id' in self.columns
 
-            # if a subset of ids was specified that excludes this row, skip.
-            if ids is not None and row['_id'] not in ids:
-                continue
+        # check that ids is not a single string
+        assert type(ids) is not str
 
-            # pull data from website
-            data = requests.get(API_ENDPOINT_EVENT + row['_id']).json()['data'][0]['attachments']
-            row_lcs = []
+        # make ids a List if it is an iterable
+        if hasattr(ids, '__iter__'):
+            ids = list(ids)
 
-            # create a LightCurve for each attachment in the data
-            for attachment in data:
-                geodata = attachment['geoData']
-                flux = [point['energy'] for point in geodata]
-                time = [point['time']/1000 for point in geodata]
-                from astropy.time import Time
-                time_obj = Time(time, format='unix')
-                lc = LightCurve(time=time_obj, flux=flux)
-                lc.meta['MISSION'] = attachment['platformId']
-                lc.meta['LABEL'] = attachment['platformId']
-                row_lcs.append(lc)
-            lclist.append(LightCurveCollection(row_lcs))
-        self['lightcurves'] = lclist
+            # check that all the given ids actually exist
+            assert all([_id in list(self._id) for _id in ids])
+
+        # if no ids are given, we assume that we will obtain website data for each
+        # event in the BolideDataFrame
+        if ids == None:
+            ids = list(self._id)
+
+        # at this point, unless the input was bad, ids should be a list
+        assert type(ids) is list
+
+        # get the data from the website by passing the ids
+        from .sources import glm_website_event
+        data = glm_website_event(ids)
+
+        # initialize empty columns in the BolideDataFrame
+        cols = data.keys()
+        for col in cols:
+            if col == 'lightcurves':
+                self[col] = None
+            else:
+                self[col] = np.nan
+
+        # iterate through the list of ids, plugging the obtained data
+        # into the appropriate rows in the BolideDataFrame
+        for i, _id in enumerate(ids):
+
+            # find the row containing the id
+            idx = self.index[np.argmax(self._id == _id)]
+
+            # enter the data
+            for col in cols:
+                self.loc[idx, col] = data[col][i]
 
     # TODO: match on a column other than _id?
     def augment(self, new_data, time_limit=300, score_limit=5, intersection=False, outer=False):

--- a/bolides/metadata/columns.csv
+++ b/bolides/metadata/columns.csv
@@ -16,12 +16,15 @@ vel,usg,The magnitude of the bolide’s pre-impact velocity (km/s).
 detectedBy,glm,Satellite(s) that detected the bolide.
 confidenceRating,glm,Human-assigned confidence rating for the detection being a bolide.
 lightcurveStructure,glm,Human-assigned description of how bolide-like the observed light curve is.
-energy_g16,glm,Uncalibrated peak energy of the bolide as viewed from GOES-16.
-energy_g17,glm,Uncalibrated peak energy of the bolide as viewed from GOES-17.
-brightness_g16,glm,Uncalibrated peak brightness of the bolide as viewed from GOES-16.
-brightness_g17,glm,Uncalibrated peak brightness of the bolide as viewed from GOES-17.
-brightness_cat_g16,glm,Brightness category of the bolide as viewed from GOES-16.
-brightness_cat_g17,glm,Brightness category of the bolide as viewed from GOES-17.
+integrated_energy_g16,glm,Uncalibrated integrated energy of the bolide as viewed from GOES-16.
+integrated_energy_g17,glm,Uncalibrated integrated energy of the bolide as viewed from GOES-17.
+integrated_energy_g18,glm,Uncalibrated integrated energy of the bolide as viewed from GOES-18.
+peak_energy_g16,glm,Uncalibrated peak energy (median of top 5 points) of the bolide as viewed from GOES-16.
+peak_energy_g17,glm,Uncalibrated peak energy (median of top 5 points) of the bolide as viewed from GOES-17.
+peak_energy_g18,glm,Uncalibrated peak energy (median of top 5 points) of the bolide as viewed from GOES-18.
+peak_energy_cat_g16,glm,Peak energy category of the bolide as viewed from GOES-16.
+peak_energy_cat_g17,glm,Peak energy category of the bolide as viewed from GOES-17.
+peak_energy_cat_g18,glm,Peak energy category of the bolide as viewed from GOES-18.
 _id,glm,Unique identifier assigned to the bolide at neo-bolide.ndc.nasa.gov.
 description,glm,A human-written description of the bolide detection.
 groundTrack,glm,"Dict stating, for each sensor, whether or not the bolide was present in more than one pixel, and how far the bolide went."

--- a/bolides/sources.py
+++ b/bolides/sources.py
@@ -22,14 +22,19 @@ def glm_website():
     df["datetime"] = pd.to_datetime(df["datetime"])
 
     # add bolide brightness data
-    brightness_cat_g16 = []
-    brightness_g16 = []
-    brightness_cat_g17 = []
-    brightness_g17 = []
-    brightness_cat_g18 = []
-    brightness_g18 = []
-    val_cols = {'GLM-16': brightness_g16, 'GLM-17': brightness_g17, 'GLM-18': brightness_g18}
-    cat_cols = {'GLM-16': brightness_cat_g16, 'GLM-17': brightness_cat_g17, 'GLM-18': brightness_cat_g18}
+    peak_energy_cat_g16 = []
+    peak_energy_g16 = []
+    peak_energy_cat_g17 = []
+    peak_energy_g17 = []
+    peak_energy_cat_g18 = []
+    peak_energy_g18 = []
+    val_cols = {'GLM-16': peak_energy_g16,
+                'GLM-17': peak_energy_g17,
+                'GLM-18': peak_energy_g18}
+    cat_cols = {'GLM-16': peak_energy_cat_g16,
+                'GLM-17': peak_energy_cat_g17,
+                'GLM-18': peak_energy_cat_g18}
+
     for brightness in df.brightness:
         for sat in ['GLM-16', 'GLM-17', 'GLM-18']:
             if sat in brightness:
@@ -38,12 +43,14 @@ def glm_website():
             else:
                 cat_cols[sat].append("")
                 val_cols[sat].append(np.nan)
-    df['brightness_cat_g16'] = brightness_cat_g16
-    df['brightness_g16'] = brightness_g16
-    df['brightness_cat_g17'] = brightness_cat_g17
-    df['brightness_g17'] = brightness_g17
-    df['brightness_cat_g18'] = brightness_cat_g18
-    df['brightness_g18'] = brightness_g18
+
+    df['peak_energy_cat_g16'] = peak_energy_cat_g16
+    df['peak_energy_g16'] = peak_energy_g16
+    df['peak_energy_cat_g17'] = peak_energy_cat_g17
+    df['peak_energy_g17'] = peak_energy_g17
+    df['peak_energy_cat_g18'] = peak_energy_cat_g18
+    df['peak_energy_g18'] = peak_energy_g18
+
     del df['brightness']
 
     gdf = add_geometry(df)
@@ -243,7 +250,7 @@ def glm_website_event(ids):
     """
 
     # dict to store returned data
-    data = {'energy_g16': [], 'energy_g17': [], 'energy_g18': [], 'lightcurves': []}
+    data = {'integrated_energy_g16': [], 'integrated_energy_g17': [], 'integrated_energy_g18': [], 'lightcurves': []}
 
     for bid in tqdm(ids, "Downloading data"):  # for each bolide
 
@@ -252,7 +259,8 @@ def glm_website_event(ids):
         row_lcs = []
 
         # dict to store integrated energies for this event
-        integrated_energies = {'g16': 0, 'g17': 0, 'g18': 0}
+        # initialize as nan to represent lack of data
+        integrated_energies = {'g16': np.nan, 'g17': np.nan, 'g18': np.nan}
 
         # loop over the attachments returned in the data
         for attachment in web_data:
@@ -260,6 +268,10 @@ def glm_website_event(ids):
             # get the satellite ID and geodata
             platform = attachment['platformId']
             geodata = attachment['geoData']
+
+            # since there is data for this satellite, set to zero if nan
+            if integrated_energies[platform.lower()] is np.nan:
+                integrated_energies[platform.lower()] = 0
 
             # obtain flux from the geodata, and sum it up to get
             # integrated energy
@@ -282,6 +294,6 @@ def glm_website_event(ids):
 
         # enter the integrated energy into the data dict
         for sat, value in integrated_energies.items():
-            data[f'energy_{sat}'].append(value)
+            data[f'integrated_energy_{sat}'].append(value)
 
     return data


### PR DESCRIPTION
This PR closes #22 by removing the ``energy_g16`` and ``energy_g17`` from the initial BolideDataFrame obtained upon a call of ``BolideDataFrame('glm-website')``. To add integrated energies to the BolideDataFrame, the user can now use the ``add_website_data`` method, which previously only added ``LightCurveCollection`` objects.

The main logic behind ``add_website_data`` has been moved from the method in ``bdf.py`` to a function ``glm_website_event`` in ``sources.py``. This reduces the complexity of the main BolideDataFrame class, and also allows ``glm_website_event`` to be used independently of the class. (Use case: user has a list of bolide IDs, and wants to get their light curves or integrated energies).

One additional minor change is adding the GOES-18 brightness and brightness category data to the initial BolideDataFrame, which previously only contained it for GOES-16 and GOES-17.