### PR TITLE
19 get closest by loc should use haversine distance

### DIFF
--- a/bolides/astro_utils.py
+++ b/bolides/astro_utils.py
@@ -162,3 +162,91 @@ def sol_lon_to_jd(lon, year):
         TDelta += 365.2596
     JD = JD0 + TDelta
     return JD
+
+def haversine(lat1, lon1, lat2, lon2):
+        """
+        Calculates the haversine distance between two points in km.
+        Inputs are in degrees.
+
+        Parameters
+        ----------
+        lat1, lon1 : float
+            Latitude and longitude of the first point in degrees.
+        lat2, lon2 : float
+            Latitude and longitude of the second point in degrees.
+
+        Returns
+        -------
+        float
+            The haversine distance between the two points in kilometers.
+        """
+        R = 6371  # Earth radius in km
+
+        # Convert degrees to radians
+        lat1, lon1, lat2, lon2 = map(np.radians, [lat1, lon1, lat2, lon2])
+
+        dlat = lat2 - lat1
+        dlon = lon2 - lon1
+
+        a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
+        c = 2 * np.arcsin(np.sqrt(a))
+        return R * c
+
+def _distance_metric(x, y, fov_goes, total_time, n):
+    """
+    Measurement of how improbable it is for two bolides to be a distance apart in time and space
+
+    Parameters
+    ----------
+    x, y: tuple
+        Each tuple contains (time_seconds, latitude, longitude). They are rows from the BolideDataFrame.
+        time_seconds is the time in seconds since the start of the dataset.
+        latitude and longitude are in degrees.
+    fov_goes: float
+        The area of the GOES field of view in km^2.
+    total_time: float
+        The total time in seconds over which the bolides were observed.
+    n: int
+        The number of bolides in the dataset.
+
+    Returns
+    -------
+    float
+        The computed distance between the two points, considering both spatial and
+        temporal dimensions. This estimates the probability that two bolide events would
+        randomly be found as close together in space and time as the two being compared,
+        under a uniform random distribution.
+
+        np.pi*spatial_dist**2
+            This is the area of a circle with radius equal to the spatial distance
+            between the two points (in km²).
+
+        / fov_goes
+            Divides by the total field-of-view area (in km²) of the GOES sensor.
+            This gives the probability that two random points would be within spatial_dist
+            of each other, assuming uniform distribution over the field of view.
+
+        (2*dt/total_time)
+            dt is the absolute time difference between the two events (in seconds).
+            total_time is the total time span of the dataset (in seconds).
+            This gives the probability that two random events would be within dt of each other in time.
+
+        comb(n, 2, exact=False)
+            This is the number of unique pairs you can form from n events.
+            It scales the probability to account for all possible pairs in the dataset.
+
+        This gives the expected number of pairs (out of all possible pairs) that would be at least as
+        close in space and time as the two points being compared, under a random (uniform) distribution.
+
+        Lower values mean the pair is unusually close in space and time (less likely by chance).
+        Higher values mean the pair is not unusually close (more likely by chance).
+
+        Used as the DistanceMetric64 "distance" between the two points for the function get_closest().
+    """
+    
+    t1, x1, y1 = x
+    t2, x2, y2 = y
+    spatial_dist = haversine(x1, y1, x2, y2) 
+    dt = abs(t1 - t2)
+
+    return (np.pi*spatial_dist**2/fov_goes)*(2*dt/total_time) * comb(n, 2, exact=False)

--- a/bolides/astro_utils.py
+++ b/bolides/astro_utils.py
@@ -6,10 +6,7 @@ import ephem
 import astropy.units as u
 from astropy.coordinates import ICRS, SkyCoord
 from astropy.time import Time
-
-from pytz import timezone
-utc = timezone('UTC')
-
+from scipy.special import comb
 
 def get_phase(datetime):
     """Get lunar phase (0.01=new moon just happened, 0.99=new moon about to happen)"""

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -318,14 +318,6 @@ class BolideDataFrame(GeoDataFrame):
         compared, under a random (uniform) distribution. Effectively, given a time
         and location, this will find and cluster bolide events that are nearest to it.
 
-        If you are more confident about the position or time of the bolide, you can
-        specify weights where higher weights mean you are more confident in that
-        dimension. This will calculate the distance metric as a weighted sum of the
-        time and spatial distances. You can also set the normalization factors for
-        the time and spatial distances, which are used to scale the time and spatial
-        distances to a common scale. The default is 1 day (86400 seconds) for time
-        and 100 km for spatial distance.
-
         Parameters
         ----------
         datestr : str

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -20,6 +20,7 @@ from . import MPLSTYLE, ROOT_PATH
 from .utils import reconcile_input
 from .sources import glm_website, usg, pipeline, gmn, csv, remote
 from . import fov_utils as fu
+from .astro_utils import haversine, _distance_metric
 
 _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
                'confidenceRating', 'confidence', 'lightcurveStructure', 'energy',
@@ -29,87 +30,6 @@ _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
                'impact-e', 'alt', 'vel']
 
 utc = timezone('UTC')
-def haversine(lat1, lon1, lat2, lon2):
-        """
-        Calculates the haversine distance between two points in km.
-        Inputs are in degrees.
-
-        Parameters
-        ----------
-        lat1, lon1 : float
-            Latitude and longitude of the first point in degrees.
-        lat2, lon2 : float
-            Latitude and longitude of the second point in degrees.
-
-        Returns
-        -------
-        float
-            The haversine distance between the two points in kilometers.
-        """
-        R = 6371  # Earth radius in km
-
-        # Convert degrees to radians
-        lat1, lon1, lat2, lon2 = map(np.radians, [lat1, lon1, lat2, lon2])
-
-        dlat = lat2 - lat1
-        dlon = lon2 - lon1
-
-        a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
-        c = 2 * np.arcsin(np.sqrt(a))
-        return R * c
-def _distance_metric(x, y, fov_goes, total_time, n):
-    """
-    Measurement of how improbable it is for two bolides to be a distance apart in time and space
-
-    Parameters
-    ----------
-    x, y: tuple
-        Each tuple contains (time_seconds, latitude, longitude). They are rows from the BolideDataFrame.
-        time_seconds is the time in seconds since the start of the dataset.
-        latitude and longitude are in degrees.
-    fov_goes: float
-        The area of the GOES field of view in km^2.
-    total_time: float
-        The total time in seconds over which the bolides were observed.
-    n: int
-        The number of bolides in the dataset.
-
-    Returns
-    -------
-    float
-        The computed distance between the two points, considering both spatial and temporal dimensions. 
-        This estimates the probability that two bolide events would randomly be found as close together in space and time as the two being compared, under a uniform random distribution.
-
-        np.pi*spatial_dist**2
-            This is the area of a circle with radius equal to the spatial distance between the two points (in km²).
-
-        / fov_goes
-            Divides by the total field-of-view area (in km²) of the GOES sensor.
-            This gives the probability that two random points would be within spatial_dist of each other, assuming uniform distribution over the field of view.
-
-        (2*dt/total_time)
-            dt is the absolute time difference between the two events (in seconds).
-            total_time is the total time span of the dataset (in seconds).
-            This gives the probability that two random events would be within dt of each other in time.
-
-        comb(n, 2, exact=False)
-            This is the number of unique pairs you can form from n events.
-            It scales the probability to account for all possible pairs in the dataset.
-
-        This gives the expected number of pairs (out of all possible pairs) that would be at least as close in space and time as the two points being compared, under a random (uniform) distribution.
-
-        Lower values mean the pair is unusually close in space and time (less likely by chance).
-        Higher values mean the pair is not unusually close (more likely by chance).
-
-        Used as the DistanceMetric64 "distance" between the two points for the function get_closest().
-    """
-    
-    t1, x1, y1 = x
-    t2, x2, y2 = y
-    spatial_dist = haversine(x1, y1, x2, y2) 
-    dt = abs(t1 - t2)
-
-    return (np.pi*spatial_dist**2/fov_goes)*(2*dt/total_time) * comb(n, 2, exact=False)
 
 class BolideDataFrame(GeoDataFrame):
     """
@@ -145,7 +65,6 @@ class BolideDataFrame(GeoDataFrame):
         Whether or not to rearrange the columns, if coming from a CSV or Pickle.
     """
     
-
     def __init__(self, *args, **kwargs):
 
         if len(args)==0 and len(kwargs)==0:
@@ -244,7 +163,6 @@ class BolideDataFrame(GeoDataFrame):
         descriptions = pd.read_csv(ROOT_PATH+'/metadata/columns.csv', index_col='column')
         self.descriptions = descriptions[descriptions.sources.isin([source, 'all'])]
         
-
     def annotate(self):
         """Add metadata to bolide detections"""
         from .astro_utils import get_phase, get_solarhour, get_sun_alt
@@ -393,9 +311,20 @@ class BolideDataFrame(GeoDataFrame):
 
     def get_closest(self, datestr=None, lon=None, lat=None, k=1, time_weight=1, loc_weight=1, time_scale=86400, loc_scale=100):
         """
-        Get the n bolides closest to a given iso-format date string and to a given longitude and latitude in degrees. This is calculated using BallTree and a custom distance metric that finds the expected number of pairs of bolides that would be at least as close in space and time as the two points being compared, under a random (uniform) distribution. Effectively, given a time and location, this will find and cluster bolide events that are nearest to it.
+        Get the n bolides closest to a given iso-format date string and to a given
+        longitude and latitude in degrees. This is calculated using BallTree and a
+        custom distance metric that finds the expected number of pairs of bolides
+        that would be at least as close in space and time as the two points being
+        compared, under a random (uniform) distribution. Effectively, given a time
+        and location, this will find and cluster bolide events that are nearest to it.
 
-        If you are more confident about the position or time of the bolide, you can specify weights where higher weights mean you are more confident in that dimension. This will calculate the distance metric as a weighted sum of the time and spatial distances. You can also set the normalization factors for the time and spatial distances, which are used to scale the time and spatial distances to a common scale. The default is 1 day (86400 seconds) for time and 100 km for spatial distance.
+        If you are more confident about the position or time of the bolide, you can
+        specify weights where higher weights mean you are more confident in that
+        dimension. This will calculate the distance metric as a weighted sum of the
+        time and spatial distances. You can also set the normalization factors for
+        the time and spatial distances, which are used to scale the time and spatial
+        distances to a common scale. The default is 1 day (86400 seconds) for time
+        and 100 km for spatial distance.
 
         Parameters
         ----------
@@ -407,9 +336,13 @@ class BolideDataFrame(GeoDataFrame):
         k : int
             Number of closest detections to return.
         time_weight : float
-            Weight to apply to the time difference in the distance metric. Higher values mean you're more confident in the time since you penalize points more heavily if they're farther in time. Default is 1.
+            Weight to apply to the time difference in the distance metric.
+            Higher values mean you're more confident in the time since you penalize
+            points more heavily if they're farther in time. Default is 1.
         loc_weight : float
-            Weight to apply to the spatial distance in the distance metric. Higher values mean you're more confident in the location since you penalize points more heavily if they're farther in distance. Default is 1.
+            Weight to apply to the spatial distance in the distance metric.
+            Higher values mean you're more confident in the location since you penalize
+            points more heavily if they're farther in distance. Default is 1.
         time_scale : float
             Normalization for time in seconds (default 1 day = 86400). 
         loc_scale : float
@@ -426,7 +359,7 @@ class BolideDataFrame(GeoDataFrame):
         elif lon is None and lat is None and datestr is not None:
             return self.get_closest_by_time(datestr, n=k)
         elif lon is None or lat is None:
-            raise ValueError("Must specify both longitude and latitude, or a date string, or all .")
+            raise ValueError("Must specify both longitude and latitude, or a date string, or all three.")
         
         
 

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -309,7 +309,7 @@ class BolideDataFrame(GeoDataFrame):
         distances = haversine(lat, lon, self['latitude'].values, self['longitude'].values)
         return self.iloc[distances.argsort()].head(n)
 
-    def get_closest(self, datestr=None, lon=None, lat=None, k=1, time_weight=1, loc_weight=1, time_scale=86400, loc_scale=100):
+    def get_closest(self, datestr=None, lon=None, lat=None, k=1):
         """
         Get the n bolides closest to a given iso-format date string and to a given
         longitude and latitude in degrees. This is calculated using BallTree and a
@@ -335,18 +335,6 @@ class BolideDataFrame(GeoDataFrame):
             Longitude and latitude in degrees to search for bolides near.
         k : int
             Number of closest detections to return.
-        time_weight : float
-            Weight to apply to the time difference in the distance metric.
-            Higher values mean you're more confident in the time since you penalize
-            points more heavily if they're farther in time. Default is 1.
-        loc_weight : float
-            Weight to apply to the spatial distance in the distance metric.
-            Higher values mean you're more confident in the location since you penalize
-            points more heavily if they're farther in distance. Default is 1.
-        time_scale : float
-            Normalization for time in seconds (default 1 day = 86400). 
-        loc_scale : float
-            Normalization for distance in km (default 100 km).
 
         Returns
         -------
@@ -366,19 +354,6 @@ class BolideDataFrame(GeoDataFrame):
         dt = datetime.fromisoformat(datestr)
         if dt.tzinfo is None:
             dt = utc.localize(dt)
-
-        if time_weight != loc_weight:
-            # Compute time difference in seconds
-            time_deltas = np.abs((self['datetime'] - dt).dt.total_seconds()) / time_scale
-
-            # Compute spatial distance in km
-            spatial_deltas = haversine(lat, lon, self['latitude'].values, self['longitude'].values) / loc_scale
-
-            # Combine with weights. The smaller the metric, the closer the bolide is to the query point.
-            metric = time_weight * time_deltas + loc_weight * spatial_deltas
-
-            # Get the k closest
-            return self.iloc[metric.argsort()].head(k)
 
         query_row = {
             'datetime': dt,

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -33,6 +33,18 @@ def haversine(lat1, lon1, lat2, lon2):
         """
         Calculates the haversine distance between two points in km.
         Inputs are in degrees.
+
+        Parameters
+        ----------
+        lat1, lon1 : float
+            Latitude and longitude of the first point in degrees.
+        lat2, lon2 : float
+            Latitude and longitude of the second point in degrees.
+
+        Returns
+        -------
+        float
+            The haversine distance between the two points in kilometers.
         """
         R = 6371  # Earth radius in km
 
@@ -45,12 +57,51 @@ def haversine(lat1, lon1, lat2, lon2):
         a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
         c = 2 * np.arcsin(np.sqrt(a))
         return R * c
-def distance_metric(x, y, fov_goes, total_time, n):
+def _distance_metric(x, y, fov_goes, total_time, n):
     """
-    Calculates the distance between two points considering time
-    ----------------------------
-    Inputs: x, y = row i, row j that have columns time_seconds, lat, long
-    Outputs: DistanceMetric64 "distance" between the two points 
+    Measurement of how improbable it is for two bolides to be a distance apart in time and space
+
+    Parameters
+    ----------
+    x, y: tuple
+        Each tuple contains (time_seconds, latitude, longitude). They are rows from the BolideDataFrame.
+        time_seconds is the time in seconds since the start of the dataset.
+        latitude and longitude are in degrees.
+    fov_goes: float
+        The area of the GOES field of view in km^2.
+    total_time: float
+        The total time in seconds over which the bolides were observed.
+    n: int
+        The number of bolides in the dataset.
+
+    Returns
+    -------
+    float
+        The computed distance between the two points, considering both spatial and temporal dimensions. 
+        This estimates the probability that two bolide events would randomly be found as close together in space and time as the two being compared, under a uniform random distribution.
+
+        np.pi*spatial_dist**2
+            This is the area of a circle with radius equal to the spatial distance between the two points (in km²).
+
+        / fov_goes
+            Divides by the total field-of-view area (in km²) of the GOES sensor.
+            This gives the probability that two random points would be within spatial_dist of each other, assuming uniform distribution over the field of view.
+
+        (2*dt/total_time)
+            dt is the absolute time difference between the two events (in seconds).
+            total_time is the total time span of the dataset (in seconds).
+            This gives the probability that two random events would be within dt of each other in time.
+
+        comb(n, 2, exact=False)
+            This is the number of unique pairs you can form from n events.
+            It scales the probability to account for all possible pairs in the dataset.
+
+        This gives the expected number of pairs (out of all possible pairs) that would be at least as close in space and time as the two points being compared, under a random (uniform) distribution.
+
+        Lower values mean the pair is unusually close in space and time (less likely by chance).
+        Higher values mean the pair is not unusually close (more likely by chance).
+
+        Used as the DistanceMetric64 "distance" between the two points for the function get_closest().
     """
     
     t1, x1, y1 = x
@@ -340,8 +391,11 @@ class BolideDataFrame(GeoDataFrame):
         distances = haversine(lat, lon, self['latitude'].values, self['longitude'].values)
         return self.iloc[distances.argsort()].head(n)
 
-    def get_closest(self, datestr=None, lon=None, lat=None, k=1):
-        """Get the n bolides closest to a given iso-format date string and to a given longitude and latitude
+    def get_closest(self, datestr=None, lon=None, lat=None, k=1, time_weight=1, loc_weight=1, time_scale=86400, loc_scale=100):
+        """
+        Get the n bolides closest to a given iso-format date string and to a given longitude and latitude in degrees. This is calculated using BallTree and a custom distance metric that finds the expected number of pairs of bolides that would be at least as close in space and time as the two points being compared, under a random (uniform) distribution. Effectively, given a time and location, this will find and cluster bolide events that are nearest to it.
+
+        If you are more confident about the position or time of the bolide, you can specify weights where higher weights mean you are more confident in that dimension. This will calculate the distance metric as a weighted sum of the time and spatial distances. You can also set the normalization factors for the time and spatial distances, which are used to scale the time and spatial distances to a common scale. The default is 1 day (86400 seconds) for time and 100 km for spatial distance.
 
         Parameters
         ----------
@@ -349,9 +403,17 @@ class BolideDataFrame(GeoDataFrame):
             ISO-format string that can be read by `~datetime.datetime.fromisoformat`.
             If the timezone is not specified, it is assumed to be in UTC.
         lon, lat : int
-            Longitude and latitude to search for bolides near.
+            Longitude and latitude in degrees to search for bolides near.
         k : int
             Number of closest detections to return.
+        time_weight : float
+            Weight to apply to the time difference in the distance metric. Higher values mean you're more confident in the time since you penalize points more heavily if they're farther in time. Default is 1.
+        loc_weight : float
+            Weight to apply to the spatial distance in the distance metric. Higher values mean you're more confident in the location since you penalize points more heavily if they're farther in distance. Default is 1.
+        time_scale : float
+            Normalization for time in seconds (default 1 day = 86400). 
+        loc_scale : float
+            Normalization for distance in km (default 100 km).
 
         Returns
         -------
@@ -364,11 +426,26 @@ class BolideDataFrame(GeoDataFrame):
         elif lon is None and lat is None and datestr is not None:
             return self.get_closest_by_time(datestr, n=k)
         elif lon is None or lat is None:
-            raise ValueError("Must specify both longitude and latitude, or a date string")
+            raise ValueError("Must specify both longitude and latitude, or a date string, or all .")
         
+        
+
         dt = datetime.fromisoformat(datestr)
         if dt.tzinfo is None:
             dt = utc.localize(dt)
+
+        if time_weight != loc_weight:
+            # Compute time difference in seconds
+            time_deltas = np.abs((self['datetime'] - dt).dt.total_seconds()) / time_scale
+
+            # Compute spatial distance in km
+            spatial_deltas = haversine(lat, lon, self['latitude'].values, self['longitude'].values) / loc_scale
+
+            # Combine with weights. The smaller the metric, the closer the bolide is to the query point.
+            metric = time_weight * time_deltas + loc_weight * spatial_deltas
+
+            # Get the k closest
+            return self.iloc[metric.argsort()].head(k)
 
         query_row = {
             'datetime': dt,
@@ -376,8 +453,8 @@ class BolideDataFrame(GeoDataFrame):
             'longitude': lon
         }
 
-        # Make a shallow copy of self to avoid modifying the original
-        bdf = self.copy()
+        # Make a deep copy of self to avoid modifying the original
+        bdf = self.copy(deep=True)
 
         # Prepend the query row
         bdf = pd.concat([pd.DataFrame([query_row]), bdf], ignore_index=True)
@@ -392,7 +469,7 @@ class BolideDataFrame(GeoDataFrame):
         total_time = (max_time - min_time).total_seconds()
         n = len(self)
 
-        metric = partial(distance_metric, fov_goes=fov_goes, total_time=total_time, n=n)
+        metric = partial(_distance_metric, fov_goes=fov_goes, total_time=total_time, n=n)
         
         X = bdf[['time_seconds', 'latitude', 'longitude']].to_numpy()
 
@@ -401,6 +478,11 @@ class BolideDataFrame(GeoDataFrame):
         dists, inds = tree.query(X[:1], k=k+1)
         
         inds = inds[0][1:]  # Exclude the first index (the query point itself)
+
+        cols = list(bdf.columns)
+        a, b = cols.index('latitude'), cols.index('longitude')
+        cols[b], cols[a] = cols[a], cols[b]
+        bdf = bdf[cols]
 
         return bdf.iloc[inds]
 

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -383,7 +383,7 @@ class BolideDataFrame(GeoDataFrame):
         bdf = pd.concat([pd.DataFrame([query_row]), bdf], ignore_index=True)
 
         # Compute time_seconds for all rows
-        bdf['time_seconds'] = (bdf.iloc[:, 0] - bdf.iloc[:, 0].min()).dt.total_seconds()
+        bdf['time_seconds'] = (bdf['datetime'] - bdf['datetime'].min()).dt.total_seconds()
 
         poly_goes = fu.get_boundary('goes', collection=True, intersection=False, crs=None)
         fov_goes = poly_goes.area / 1e6
@@ -402,7 +402,7 @@ class BolideDataFrame(GeoDataFrame):
         
         inds = inds[0][1:]  # Exclude the first index (the query point itself)
 
-        return self.iloc[inds]
+        return bdf.iloc[inds]
 
     def filter_boundary(self, boundary, intersection=False, interior=True):
         """Filter data to only points within specified boundaries.

--- a/bolides/bdf.py
+++ b/bolides/bdf.py
@@ -7,15 +7,19 @@ from tqdm import tqdm
 import numpy as np
 import pandas as pd
 import pickle
-
+from sklearn.neighbors import BallTree
 from geopandas import GeoDataFrame
+from scipy.special import comb
 
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
+from functools import partial
+
 from . import MPLSTYLE, ROOT_PATH
 from .utils import reconcile_input
 from .sources import glm_website, usg, pipeline, gmn, csv, remote
+from . import fov_utils as fu
 
 _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
                'confidenceRating', 'confidence', 'lightcurveStructure', 'energy',
@@ -25,6 +29,36 @@ _FIRST_COLS = ['datetime', 'longitude', 'latitude', 'source', 'detectedBy',
                'impact-e', 'alt', 'vel']
 
 utc = timezone('UTC')
+def haversine(lat1, lon1, lat2, lon2):
+        """
+        Calculates the haversine distance between two points in km.
+        Inputs are in degrees.
+        """
+        R = 6371  # Earth radius in km
+
+        # Convert degrees to radians
+        lat1, lon1, lat2, lon2 = map(np.radians, [lat1, lon1, lat2, lon2])
+
+        dlat = lat2 - lat1
+        dlon = lon2 - lon1
+
+        a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
+        c = 2 * np.arcsin(np.sqrt(a))
+        return R * c
+def distance_metric(x, y, fov_goes, total_time, n):
+    """
+    Calculates the distance between two points considering time
+    ----------------------------
+    Inputs: x, y = row i, row j that have columns time_seconds, lat, long
+    Outputs: DistanceMetric64 "distance" between the two points 
+    """
+    
+    t1, x1, y1 = x
+    t2, x2, y2 = y
+    spatial_dist = haversine(x1, y1, x2, y2) 
+    dt = abs(t1 - t2)
+
+    return (np.pi*spatial_dist**2/fov_goes)*(2*dt/total_time) * comb(n, 2, exact=False)
 
 class BolideDataFrame(GeoDataFrame):
     """
@@ -59,6 +93,8 @@ class BolideDataFrame(GeoDataFrame):
     rearrange : bool
         Whether or not to rearrange the columns, if coming from a CSV or Pickle.
     """
+    
+
     def __init__(self, *args, **kwargs):
 
         if len(args)==0 and len(kwargs)==0:
@@ -156,6 +192,7 @@ class BolideDataFrame(GeoDataFrame):
 
         descriptions = pd.read_csv(ROOT_PATH+'/metadata/columns.csv', index_col='column')
         self.descriptions = descriptions[descriptions.sources.isin([source, 'all'])]
+        
 
     def annotate(self):
         """Add metadata to bolide detections"""
@@ -290,7 +327,7 @@ class BolideDataFrame(GeoDataFrame):
         Parameters
         ----------
         lon, lat : int
-            Longitude and latitude to search for bolides near.
+            Longitude and latitude in degrees to search for bolides near.
         n : int
             Number of closest detections to return.
 
@@ -300,10 +337,72 @@ class BolideDataFrame(GeoDataFrame):
             The filtered data.
 
         """
-        lon_diff = (self['longitude'] - lon).abs()
-        lat_diff = (self['latitude'] - lat).abs()
-        tot_diff = lon_diff + lat_diff
-        return self.iloc[tot_diff.argsort()].head(n)
+        distances = haversine(lat, lon, self['latitude'].values, self['longitude'].values)
+        return self.iloc[distances.argsort()].head(n)
+
+    def get_closest(self, datestr=None, lon=None, lat=None, k=1):
+        """Get the n bolides closest to a given iso-format date string and to a given longitude and latitude
+
+        Parameters
+        ----------
+        datestr : str
+            ISO-format string that can be read by `~datetime.datetime.fromisoformat`.
+            If the timezone is not specified, it is assumed to be in UTC.
+        lon, lat : int
+            Longitude and latitude to search for bolides near.
+        k : int
+            Number of closest detections to return.
+
+        Returns
+        -------
+        bdf : `~BolideDataFrame`
+            The filtered data.
+
+        """
+        if datestr is None and (lon is not None and lat is not None):
+            return self.get_closest_by_loc(lon, lat, n=k)
+        elif lon is None and lat is None and datestr is not None:
+            return self.get_closest_by_time(datestr, n=k)
+        elif lon is None or lat is None:
+            raise ValueError("Must specify both longitude and latitude, or a date string")
+        
+        dt = datetime.fromisoformat(datestr)
+        if dt.tzinfo is None:
+            dt = utc.localize(dt)
+
+        query_row = {
+            'datetime': dt,
+            'latitude': lat,
+            'longitude': lon
+        }
+
+        # Make a shallow copy of self to avoid modifying the original
+        bdf = self.copy()
+
+        # Prepend the query row
+        bdf = pd.concat([pd.DataFrame([query_row]), bdf], ignore_index=True)
+
+        # Compute time_seconds for all rows
+        bdf['time_seconds'] = (bdf.iloc[:, 0] - bdf.iloc[:, 0].min()).dt.total_seconds()
+
+        poly_goes = fu.get_boundary('goes', collection=True, intersection=False, crs=None)
+        fov_goes = poly_goes.area / 1e6
+        min_time = self['datetime'].min()
+        max_time = self['datetime'].max()
+        total_time = (max_time - min_time).total_seconds()
+        n = len(self)
+
+        metric = partial(distance_metric, fov_goes=fov_goes, total_time=total_time, n=n)
+        
+        X = bdf[['time_seconds', 'latitude', 'longitude']].to_numpy()
+
+        tree = BallTree(X, metric=metric)
+        
+        dists, inds = tree.query(X[:1], k=k+1)
+        
+        inds = inds[0][1:]  # Exclude the first index (the query point itself)
+
+        return self.iloc[inds]
 
     def filter_boundary(self, boundary, intersection=False, interior=True):
         """Filter data to only points within specified boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.6.0"
 authors = [
   { name="Anthony Ozerov", email="ozerov@berkeley.edu" },
   { name="Jeffrey Smith", email="jsmith@seti.org" },
+  { name="Kaitlyn Chen", email="kaichen@hmc.edu" },
 ]
 description = "A package to analyze bolide data"
 readme = "README.rst"
@@ -34,6 +35,7 @@ dependencies = [
     "watermark",
     "beautifulsoup4",
     "plotly",
+    "scipy",
 ]
 
 [project.urls]


### PR DESCRIPTION
These have all the fixes from the PR #40  and the weights for `get_closest()` are deleted. So the haversine distance is now being used for `get_closest_by_loc()`, and we now use a probability calculation to find the "closest" bolide from a given time and location.