### PR TITLE
Fix pkg_resources deprecation and GLM brightness KeyError

### DIFF
--- a/bolides/__init__.py
+++ b/bolides/__init__.py
@@ -2,8 +2,8 @@ API_ENDPOINT_EVENTLIST = "https://neo-bolide.ndc.nasa.gov/service/event/public"
 API_ENDPOINT_EVENT = "https://neo-bolide.ndc.nasa.gov/service/event/"
 MPLSTYLE = "ggplot"
 
-import pkg_resources
-ROOT_PATH = pkg_resources.resource_filename('bolides', '.')
+from pathlib import Path
+ROOT_PATH = str(Path(__file__).parent)
 GLM_FOV_PATH = ROOT_PATH + '/data/GLM_FOV_edges.nc'
 
 from .bolide import *

--- a/bolides/sources.py
+++ b/bolides/sources.py
@@ -43,7 +43,8 @@ def glm_website():
         for sat in ['GLM-16', 'GLM-17', 'GLM-18', 'GLM-19']:
             if sat in brightness:
                 cat_cols[sat].append(brightness[sat]['category'])
-                val_cols[sat].append(brightness[sat]['value'])
+                # Note: 'value' is sometimes missing from brightness[sat], if so, fill with np.nan
+                val_cols[sat].append(brightness[sat].get('value', np.nan))
             else:
                 cat_cols[sat].append("")
                 val_cols[sat].append(np.nan)


### PR DESCRIPTION
Replace deprecated pkg_resources with pathlib for ROOT_PATH resolution. Guard against missing 'value' key in GLM brightness data by falling back to np.nan.